### PR TITLE
Include defaults conda channel

### DIFF
--- a/docs/source/content/00_Installation.rst
+++ b/docs/source/content/00_Installation.rst
@@ -28,7 +28,7 @@ Use the installation command with conda:
 
 .. code-block:: 
 
-    conda install stereopy -c stereopy -c grst -c numba -c conda-forge -c bioconda -c fastai
+    conda install stereopy -c stereopy -c grst -c numba -c conda-forge -c bioconda -c fastai -c defaults
 
 PyPI
 ----


### PR DESCRIPTION
If the `defaults` conda channel is disabled, like in case of miniforge, then add that one as well so the installation can happend without any errors.